### PR TITLE
fix(style): Harmonize Border and Divider Colors

### DIFF
--- a/src/app/theme.css
+++ b/src/app/theme.css
@@ -34,3 +34,19 @@ body {
 .bg-accent {
   background-color: rgb(var(--color-accent));
 }
+
+/*
+  Custom utility classes to apply our theme's secondary color
+  for borders, dividers, and rings.
+*/
+.auvra-border {
+  border-color: rgb(var(--color-secondary) / 0.5);
+}
+
+.auvra-divide > :not([hidden]) ~ :not([hidden]) {
+  border-color: rgb(var(--color-secondary) / 0.5);
+}
+
+.auvra-ring-secondary {
+  --tw-ring-color: rgb(var(--color-secondary));
+}

--- a/src/components/product/ProductCard.js
+++ b/src/components/product/ProductCard.js
@@ -11,7 +11,7 @@ export default function ProductCard({ product, locale }) {
   const productPageUrl = `/${locale}/product/${handle}`;
 
   return (
-    <article className="group relative flex flex-col overflow-hidden rounded-lg border border-secondary/50 bg-background shadow-sm transition-shadow hover:shadow-md">
+    <article className="group relative flex flex-col overflow-hidden rounded-lg border bg-background shadow-sm transition-shadow hover:shadow-md auvra-border">
       <Link href={externalUrl || productPageUrl} target={externalUrl ? '_blank' : '_self'}>
         <div className="aspect-h-1 aspect-w-1 bg-secondary/20">
           {featuredImage && (

--- a/src/components/product/ProductGallery.js
+++ b/src/components/product/ProductGallery.js
@@ -31,8 +31,8 @@ export default function ProductGallery({ images, title, featuredImage }) {
           <li key={image.url} className="h-20 w-20">
             <button
               onClick={() => setSelectedImage(image)}
-              className={`h-full w-full rounded-lg transition hover:ring-2 hover:ring-primary/50 focus:outline-none focus:ring-2 focus:ring-primary ${
-                selectedImage.url === image.url ? 'ring-2 ring-primary' : 'ring-1 ring-secondary'
+              className={`h-full w-full rounded-lg transition hover:ring-2 hover:ring-primary/50 focus:outline-none focus:ring-2 focus:ring-primary ring-1 ${
+                selectedImage.url === image.url ? 'ring-2 ring-primary' : 'auvra-ring-secondary'
               }`}
             >
               <Image

--- a/src/components/ui/Accordion.js
+++ b/src/components/ui/Accordion.js
@@ -6,7 +6,7 @@ import { useState } from 'react';
 // The wrapper component that holds all the items
 export function Accordion({ items }) {
   return (
-    <div className="w-full divide-y divide-secondary/50 rounded-xl border border-secondary/50">
+    <div className="w-full divide-y rounded-xl border auvra-border auvra-divide">
       {items.map((item, index) => (
         <AccordionItem key={index} title={item.title}>
           {item.content}


### PR DESCRIPTION
This PR fixes a persistent styling bug by defining custom CSS utility classes for borders, dividers, and rings. This ensures a consistent, light grey is used throughout the site, harmonizing the visual theme. Closes #71.